### PR TITLE
Stops counter recursion when timer is done

### DIFF
--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -143,6 +143,7 @@ Stopwatch.prototype = {
 		if(this.runTimer) {
 
 			var time;
+			var doneFlag = false;
 			if(this.countDownMS) { // run clock backwards declaring done when reached 0 
 				time = this.countDownMS - timediff; 
 
@@ -157,6 +158,7 @@ Stopwatch.prototype = {
 						this.doneFired = true;
 						this.done = true;
 						this.emit('done');
+						doneFlag = true;
 					}
 
 				} else if (time < this.almostDoneMS) {
@@ -176,9 +178,10 @@ Stopwatch.prototype = {
 
 			this.emit('time',{ms: this.ms});
 			var that = this;
-
-			this.refreshTimer = setTimeout(function(){that.counter(starttime);},this.refreshRateMS);
-
+			
+			if (!doneFlag) {
+				this.refreshTimer = setTimeout(function(){that.counter(starttime);},this.refreshRateMS);
+			}
 		} else {
 			clearTimeout(this.refreshTimer);
 			this.stoptime = timediff;


### PR DESCRIPTION
When timer is done, the `counter` recursion is stopped, fixing bugs with the `done` function being called upon every "tick".
