### PR TITLE
Fix mistakes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ timer.onDone(function(){
 });
 
 // Fires when the timer is almost complete - default is 10 seconds remaining. Change with 'almostDoneMS' option
-timer.onAlmostdone(function() {
+timer.onAlmostDone(function() {
 	console.log('Timer is almost complete');
 });
 
 //These methods are chainable
-timer.onTime(cb).onAlmostdone(cb).onDone(cb);
+timer.onTime(cb).onAlmostDone(cb).onDone(cb);
 
 ```
 


### PR DESCRIPTION
A few of the onAlmostDone were not cased properly making the examples break.