### PR TITLE
BUGFIX - 'almostdone' event was not firing properly

### DIFF
--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -204,7 +204,7 @@ Stopwatch.prototype = {
 	 * @returns {Object} itself for chaining
 	 */
 	onAlmostDone: function(cb) {
-		this.on('almostDone', cb);
+		this.on('almostdone', cb);
 		return this;
 	},
 


### PR DESCRIPTION
AlmostDone event was not firing properly because of string case issue