### PR TITLE
Swapping lodash for lodash.assignin

### DIFF
--- a/lib/Stopwatch.js
+++ b/lib/Stopwatch.js
@@ -4,7 +4,7 @@
 
 
 var EventEmitter = require('events').EventEmitter;
-var _ = require('lodash');
+var assignIn = require('lodash.assignin');
 
 
 
@@ -230,6 +230,6 @@ Stopwatch.prototype = {
 };
 
 
-_.extend(Stopwatch.prototype, EventEmitter.prototype);
+assignIn(Stopwatch.prototype, EventEmitter.prototype);
 module.exports = Stopwatch;
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "countdown"
   ],
   "dependencies": {
-    "lodash": "^2.4.1"
+    "lodash.assignin": "^4.2.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Having the full `lodash` package as a dependency is unnecessary, instead we can just require the function we need and save ~500kb